### PR TITLE
Add back the git push to the gh-pages branch to the deploy script

### DIFF
--- a/deploy
+++ b/deploy
@@ -24,5 +24,6 @@ git commit -a -m "Update release - `date -u`"
 # Need to add the 5apps remote:
 #   git remote add 5apps git@5apps.com:remotestorage_remotestorageio.git
 git push 5apps gh-pages:master
+git push origin gh-pages
 git checkout master
 rm -rf tmp


### PR DESCRIPTION
Partially reverts 8d292e8

I've just realized the deploy script doesn't do a pull, I'm also going to add that, otherwise it's going to be painful to have different users deploying it